### PR TITLE
Update vfs.rs for the need of the new path-resolution system.

### DIFF
--- a/rcore-fs/src/vfs.rs
+++ b/rcore-fs/src/vfs.rs
@@ -257,6 +257,7 @@ pub enum FsError {
     IOCTLError,
     NoDevice,
     Again, // E_AGAIN, when no data is available, never happens in fs
+    SymLoop, //E_LOOP
 }
 
 impl fmt::Display for FsError {
@@ -277,7 +278,7 @@ impl std::error::Error for FsError {}
 pub type Result<T> = result::Result<T, FsError>;
 
 /// Abstract file system
-pub trait FileSystem: Sync {
+pub trait FileSystem: Sync+Send {
     /// Sync all data to the storage
     fn sync(&self) -> Result<()>;
 


### PR DESCRIPTION
Update vfs for the need of the new path-resolution system.
1. Add Send mark to FileSystem. (I can't tell why Send is necessary and right here, but adding the mark does not conflict with current SFS, at least now.)
Note that updating version of bitvec of SFS may break Send and Sync.
2. Add SymLoop (E_LOOP) for bad path resolution.

(Both modifications are required for new vfs, but are compatible with current code, I think.)