### PR TITLE
Added INode::create2() which allows creating devicefile with argument.

### DIFF
--- a/rcore-fs-sfs/src/lib.rs
+++ b/rcore-fs-sfs/src/lib.rs
@@ -498,7 +498,7 @@ impl vfs::INode for INodeImpl {
         }
         self._resize(len)
     }
-    fn create(&self, name: &str, type_: vfs::FileType, _mode: u32) -> vfs::Result<Arc<vfs::INode>> {
+    fn create2(&self, name: &str, type_: vfs::FileType, _mode: u32, data: usize)->vfs::Result<Arc<vfs::INode>>{
         let info = self.metadata()?;
         if info.type_ != vfs::FileType::Dir {
             return Err(FsError::NotDir);
@@ -517,6 +517,7 @@ impl vfs::INode for INodeImpl {
             vfs::FileType::File => self.fs.new_inode_file()?,
             vfs::FileType::SymLink => self.fs.new_inode_symlink()?,
             vfs::FileType::Dir => self.fs.new_inode_dir(self.id)?,
+            vfs::FileType::CharDevice => self.fs.new_inode_chardevice(data)?,
             _ => return Err(vfs::FsError::InvalidParam),
         };
 
@@ -533,6 +534,7 @@ impl vfs::INode for INodeImpl {
 
         Ok(inode)
     }
+
     fn link(&self, name: &str, other: &Arc<INode>) -> vfs::Result<()> {
         let info = self.metadata()?;
         if info.type_ != vfs::FileType::Dir {

--- a/rcore-fs/src/vfs.rs
+++ b/rcore-fs/src/vfs.rs
@@ -32,7 +32,14 @@ pub trait INode: Any + Sync + Send {
     fn resize(&self, len: usize) -> Result<()>;
 
     /// Create a new INode in the directory
-    fn create(&self, name: &str, type_: FileType, mode: u32) -> Result<Arc<INode>>;
+    fn create(&self, name: &str, type_: FileType, mode: u32) -> Result<Arc<INode>>{
+        self.create2(name, type_, mode, 0)
+    }
+
+    /// Create a new INode in the directory, with a data field for usages like device file.
+    fn create2(&self, name: &str, type_: FileType, mode: u32, data: usize) -> Result<Arc<INode>>{
+        self.create(name, type_, mode)
+    }
 
     /// Create a hard link `name` to `other`
     fn link(&self, name: &str, other: &Arc<INode>) -> Result<()>;


### PR DESCRIPTION
Default INode::create2() and INode::create() implements each other so (perhaps) no worry about compatability.
Implemented INode::create2() for SFS.