### PR TITLE
Fix panic when unzip

### DIFF
--- a/rcore-fs-fuse/src/main.rs
+++ b/rcore-fs-fuse/src/main.rs
@@ -73,9 +73,9 @@ fn main() {
         "sfs" => {
             let file = OpenOptions::new()
                 .read(true)
-                .write(true)
-                .create(true)
-                .truncate(true)
+                .write(create)
+                .create(create)
+                .truncate(create)
                 .open(&opt.image)
                 .expect("failed to open image");
             let device = Mutex::new(file);


### PR DESCRIPTION
Should not create/write/truncate the image when unzipping data.