### PR TITLE
Add code for Windows.

### DIFF
--- a/rcore-fs/Cargo.toml
+++ b/rcore-fs/Cargo.toml
@@ -11,5 +11,9 @@ libc = { version = "0.2", optional = true }
 [dev-dependencies]
 tempfile = "3"
 
+[target.'cfg(windows)'.dependencies]
+filetime = "0.2"
+winapi = "0.3"
+
 [features]
 std = ["libc"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2020-02-20


### PR DESCRIPTION
I've passed the tests and successfully created an image for rCore_tutorial.

Some Unix-specific file metadata is simply ignored and set to 0 on Windows. Maybe it needs to investigate more.

Note that toolchain is frozen to nightly-2020_02_20 in this pull request. I don't know if it is necessary.