### PR TITLE
chore(deps): update to latest rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "rcore-fs",
     "rcore-fs-sfs",

--- a/rcore-fs-fuse/Cargo.toml
+++ b/rcore-fs-fuse/Cargo.toml
@@ -13,7 +13,7 @@ libc = "0.2"
 log = "0.4"
 fuse = { version = "0.3", optional = true }
 structopt = "0.3"
-env_logger = "0.9"
+env_logger = "0.11"
 git-version = "0.3"
 rcore-fs = { path = "../rcore-fs", features = ["std"] }
 rcore-fs-sfs = { path = "../rcore-fs-sfs" }

--- a/rcore-fs-hostfs/Cargo.toml
+++ b/rcore-fs-hostfs/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 rcore-fs = { path = "../rcore-fs", features = ["std"] }
-nix = "0.23"
+nix = { version = "0.29", features = ["fs"] }
 log = "0.4"

--- a/rcore-fs-sefs/Cargo.toml
+++ b/rcore-fs-sefs/Cargo.toml
@@ -9,7 +9,7 @@ rcore-fs = { path = "../rcore-fs" }
 static_assertions = "1.1"
 spin = "0.9"
 log = "0.4"
-bitvec = { version = "0.22", default-features = false, features = ["alloc"] }
+bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [features]
 std = ["rcore-fs/std"]

--- a/rcore-fs-sefs/src/lib.rs
+++ b/rcore-fs-sefs/src/lib.rs
@@ -457,7 +457,7 @@ pub struct SEFS {
     /// on-disk superblock
     super_block: RwLock<Dirty<SuperBlock>>,
     /// blocks in use are marked 0
-    free_map: RwLock<Dirty<BitVec<Lsb0, u8>>>,
+    free_map: RwLock<Dirty<BitVec<u8, Lsb0>>>,
     /// inode list
     inodes: RwLock<BTreeMap<INodeId, Weak<INodeImpl>>>,
     /// device
@@ -491,7 +491,7 @@ impl SEFS {
             let block_id = Self::get_freemap_block_id_of_group(i);
             meta_file.read_block(
                 block_id,
-                &mut free_map.as_mut_raw_slice()[BLKSIZE * i..BLKSIZE * (i + 1)],
+                &mut free_map.as_raw_mut_slice()[BLKSIZE * i..BLKSIZE * (i + 1)],
             )?;
         }
 
@@ -725,7 +725,7 @@ trait BitsetAlloc {
     fn alloc(&mut self) -> Option<usize>;
 }
 
-impl BitsetAlloc for BitVec<Lsb0, u8> {
+impl BitsetAlloc for BitVec<u8, Lsb0> {
     fn alloc(&mut self) -> Option<usize> {
         // TODO: more efficient
         let id = (0..self.len()).find(|&i| self[i]);
@@ -736,12 +736,12 @@ impl BitsetAlloc for BitVec<Lsb0, u8> {
     }
 }
 
-impl AsBuf for BitVec<Lsb0, u8> {
+impl AsBuf for BitVec<u8, Lsb0> {
     fn as_buf(&self) -> &[u8] {
         self.as_raw_slice()
     }
     fn as_buf_mut(&mut self) -> &mut [u8] {
-        self.as_mut_raw_slice()
+        self.as_raw_mut_slice()
     }
 }
 

--- a/rcore-fs-sfs/Cargo.toml
+++ b/rcore-fs-sfs/Cargo.toml
@@ -9,7 +9,7 @@ rcore-fs = { path = "../rcore-fs" }
 static_assertions = "1.1"
 spin = "0.9"
 log = "0.4"
-bitvec = { version = "0.22", default-features = false, features = ["alloc"] }
+bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-tempfile = "3.2"
+tempfile = "3.10"

--- a/rcore-fs-sfs/src/lib.rs
+++ b/rcore-fs-sfs/src/lib.rs
@@ -748,7 +748,7 @@ pub struct SimpleFileSystem {
     /// on-disk superblock
     super_block: RwLock<Dirty<SuperBlock>>,
     /// blocks in use are mared 0
-    free_map: RwLock<Dirty<BitVec<Lsb0, u8>>>,
+    free_map: RwLock<Dirty<BitVec<u8, Lsb0>>>,
     /// inode list
     inodes: RwLock<BTreeMap<INodeId, Weak<INodeImpl>>>,
     /// device
@@ -1007,7 +1007,7 @@ trait BitsetAlloc {
     fn alloc(&mut self) -> Option<usize>;
 }
 
-impl BitsetAlloc for BitVec<Lsb0, u8> {
+impl BitsetAlloc for BitVec<u8, Lsb0> {
     fn alloc(&mut self) -> Option<usize> {
         // TODO: more efficient
         let id = (0..self.len()).find(|&i| self[i]);
@@ -1018,12 +1018,12 @@ impl BitsetAlloc for BitVec<Lsb0, u8> {
     }
 }
 
-impl AsBuf for BitVec<Lsb0, u8> {
+impl AsBuf for BitVec<u8, Lsb0> {
     fn as_buf(&self) -> &[u8] {
         self.as_raw_slice()
     }
     fn as_buf_mut(&mut self) -> &mut [u8] {
-        self.as_mut_raw_slice()
+        self.as_raw_mut_slice()
     }
 }
 

--- a/rcore-fs/Cargo.toml
+++ b/rcore-fs/Cargo.toml
@@ -9,7 +9,7 @@ spin = "0.9"
 libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
-tempfile = "3.2"
+tempfile = "3.10"
 
 [target.'cfg(windows)'.dependencies]
 filetime = "0.2"


### PR DESCRIPTION
Updated all of the dependencies to the latest versions. This allows rcore-fs to build in the the latest rust nightly version.